### PR TITLE
Use CompatHelper, ambiguity test fixes

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,16 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SwapStreams"
 uuid = "0b152c4a-7e29-418b-9258-223db38db9d9"
 authors = ["Zachary P. Christensen <zchristensen7@gmail.com>"]
-version = "0.2"
+version = "0.2.1"
 
 [deps]
 MappedArrays = "dbb5928d-eab1-5f90-85c2-b9b0edb7c900"

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,6 @@ MappedArrays = "dbb5928d-eab1-5f90-85c2-b9b0edb7c900"
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 
 [compat]
-MappedArrays = "0.3"
-Static = "0.5"
+MappedArrays = "0.3, 0.4"
+Static = "0.5, 0.6, 0.7, 0.8, 1.0, 1.1"
 julia = "1.4, 1.5"

--- a/src/SwapStreams.jl
+++ b/src/SwapStreams.jl
@@ -106,6 +106,10 @@ Base.read(s::SwapStream{S}, ::Type{UInt8}) where {S} = read(s.io, UInt8)
 function Base.read!(s::SwapStream{S}, a::AbstractArray{T}) where {S,T}
     Static.ifelse(is_swapping(s), bswap!, identity)(read!(s.io, a))
 end
+# Fixes an ambiguity error.
+function Base.read!(s::SwapStream{S}, a::StridedArray{T}) where {S,T}
+    invoke(Base.read!, Tuple{SwapStream{S}, AbstractArray{T}}, s, a)
+end
 function Base.read(s::SwapStream{S}, T::BitsType) where {S}
     Static.ifelse(is_swapping(s), bswap, identity)(read(s.io, T))
 end


### PR DESCRIPTION
This PR bumps a few dependencies and sets up CompatHelper so that compatibility bounds can keep up with the development of the ecosystem. It requires the `DOCUMENTER_KEY` to be setup though, not sure if it has been done already.

When testing the package on a recent version of Julia, there was an ambiguity error which I fixed so that tests now pass.